### PR TITLE
fix:解决Keys.secureFor接口输入正确的值显示not found的问题

### DIFF
--- a/src/util/common.js
+++ b/src/util/common.js
@@ -44,7 +44,7 @@ module.exports.HM_PROJECT_PATH = HM_PROJECT_PATH;
 const RN_KEYS_HMOS_MAIN_DIR = path.join(
   HM_PROJECT_PATH,
   process.env.HM_ENTRY_MODULE ?? 'entry',
-  'oh_modules/@react-native-oh-tpl/react-native-keys/src/main'
+  'oh_modules/@react-native-ohos/react-native-keys/src/main'
 );
 
 module.exports.RN_KEYS_HM_CPP_DIR = path.join(


### PR DESCRIPTION
fix:解决Keys.secureFor接口输入正确的值显示not found的问题
